### PR TITLE
Fix Firebase Swift pod static library integration

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -16,6 +16,7 @@ end
 
 target 'SnapletPjatk' do
   config = use_native_modules!
+  use_modular_headers!
 
   use_react_native!(
     :path => config[:reactNativePath],


### PR DESCRIPTION
Resolves the issue where Firebase Swift pods (FirebaseCoreInternal, FirebaseFirestore, FirebaseStorage) could not be integrated as static libraries due to missing module definitions in their dependencies.