### PR TITLE
Fix leveldb and Firebase pod build issues

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -37,5 +37,12 @@ target 'SnapletPjatk' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
+
+    # Fix for leveldb and other build issues
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES'] = 'YES'
+      end
+    end
   end
 end


### PR DESCRIPTION
Add CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES setting to resolve "Internal inconsistency error" for leveldb-library and other Firebase dependencies during Xcode builds.