### PR TITLE
Fix gRPC-Core compilation error for iOS

### DIFF
--- a/ios/BUILD_FIX.md
+++ b/ios/BUILD_FIX.md
@@ -1,0 +1,70 @@
+# gRPC-Core Build Fix
+
+## Problem
+The build was failing with this error:
+```
+CompileC ... gRPC-Core ... xds_wrr_locality.o ... xds_wrr_locality.cc
+```
+
+## Solution Applied
+
+### Changes to `ios/Podfile`:
+
+1. **Static Framework Flag**: Added `$RNFirebaseAsStaticFramework = true` to build Firebase as static framework
+
+2. **Version Pinning**: Pinned gRPC-Core to version 1.59.2 with modular headers disabled:
+   ```ruby
+   pod 'gRPC-Core', '1.59.2', :modular_headers => false
+   ```
+
+3. **Build Settings**: Added specific compiler flags for gRPC-Core:
+   - `GRPC_BAZEL_BUILD=1` preprocessor definition
+   - `CLANG_WARN_STRICT_PROTOTYPES = NO`
+   - `CLANG_CXX_LANGUAGE_STANDARD = c++17`
+   - `GCC_WARN_INHIBIT_ALL_WARNINGS = YES`
+
+## Steps to Rebuild
+
+Run these commands from the project root:
+
+```bash
+# Clean iOS build artifacts
+cd ios
+rm -rf Pods Podfile.lock DerivedData
+cd ..
+
+# Reinstall pods
+cd ios && pod install --repo-update && cd ..
+
+# Build the project
+npm run ios
+```
+
+Or use the convenience script:
+```bash
+npm run ios:clean
+npm run ios
+```
+
+## Why This Fix Works
+
+- **Static Framework**: Reduces linking complexity and avoids dynamic framework issues
+- **Version Pinning**: Ensures we use a tested, compatible version of gRPC-Core
+- **Build Settings**: Suppresses warnings and configures the compiler to properly handle gRPC-Core's C++ code
+- **C++17 Standard**: Ensures compatibility with modern C++ features used in gRPC-Core
+
+## If Issues Persist
+
+If you still encounter build errors:
+
+1. Clean Xcode derived data:
+   ```bash
+   rm -rf ~/Library/Developer/Xcode/DerivedData/*
+   ```
+
+2. Clean React Native cache:
+   ```bash
+   npx react-native start --reset-cache
+   ```
+
+3. Ensure you're using Xcode 14+ with CocoaPods 1.12+

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -13,6 +13,9 @@ require Pod::Executable.execute_command('node', ['-p',
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
+# Fix for gRPC-Core build issues
+$RNFirebaseAsStaticFramework = true
+
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil
   Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
@@ -36,6 +39,9 @@ target 'SnapletPjatk' do
     # Pods for testing
   end
 
+  # Pin gRPC-Core to a compatible version to avoid build issues
+  pod 'gRPC-Core', '1.59.2', :modular_headers => false
+
   post_install do |installer|
     # https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/react_native_pods.rb#L197-L202
     react_native_post_install(
@@ -52,6 +58,15 @@ target 'SnapletPjatk' do
 
         # Fix for Hermes script execution issues
         config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'i386'
+
+        # Fix for gRPC-Core C++ compilation issues
+        if target.name == 'gRPC-Core'
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'GRPC_BAZEL_BUILD=1'
+          config.build_settings['CLANG_WARN_STRICT_PROTOTYPES'] = 'NO'
+          config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++17'
+          config.build_settings['GCC_WARN_INHIBIT_ALL_WARNINGS'] = 'YES'
+        end
       end
     end
 


### PR DESCRIPTION
Resolves compilation errors for xds_wrr_locality.cc in gRPC-Core target.

Changes:
- Pin gRPC-Core to version 1.59.2 with modular headers disabled
- Add $RNFirebaseAsStaticFramework flag for static framework build
- Configure C++17 standard and required compiler flags for gRPC-Core
- Add GRPC_BAZEL_BUILD preprocessor definition
- Suppress strict prototypes warnings for gRPC-Core target

Users should run: npm run ios:clean && npm run ios