### PR TITLE
Fix BoringSSL-GRPC compilation error on iOS

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -81,6 +81,16 @@ target 'SnapletPjatk' do
           config.build_settings['WARNING_CFLAGS'] = '-Wno-everything'
           config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
         end
+
+        # Fix for BoringSSL-GRPC compilation issues
+        if target.name == 'BoringSSL-GRPC'
+          config.build_settings['CLANG_WARN_STRICT_PROTOTYPES'] = 'NO'
+          config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'gnu++17'
+          config.build_settings['CLANG_CXX_LIBRARY'] = 'libc++'
+          config.build_settings['GCC_WARN_INHIBIT_ALL_WARNINGS'] = 'YES'
+          config.build_settings['WARNING_CFLAGS'] = '-Wno-everything'
+          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+        end
       end
     end
 


### PR DESCRIPTION
Add build configuration for BoringSSL-GRPC target to resolve tls_record.cc compilation failures on arm64 architecture. This follows the same pattern used for gRPC-Core and gRPC-C++ fixes by setting:
- C++ language standard to gnu++17
- C++ library to libc++
- Disabling strict prototype warnings
- Setting iOS deployment target to 13.0

Resolves compilation error: CompileC tls_record.o