### PR TITLE
Disable assembly optimizations in BoringSSL-GRPC to fix -G flag error

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -90,6 +90,9 @@ target 'SnapletPjatk' do
           config.build_settings['GCC_WARN_INHIBIT_ALL_WARNINGS'] = 'YES'
           config.build_settings['WARNING_CFLAGS'] = '-Wno-everything'
           config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+          config.build_settings['OTHER_CFLAGS'] = '$(inherited) -DOPENSSL_NO_ASM'
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+          config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'OPENSSL_NO_ASM=1'
         end
       end
     end


### PR DESCRIPTION
The -G compiler flag is not supported for arm64-apple-ios targets. This flag is typically used in BoringSSL's assembly optimizations.

Adding OPENSSL_NO_ASM=1 preprocessor definition to disable assembly code and use C implementations instead, which resolves the compilation error: "unsupported option '-G' for target 'arm64-apple-ios13.0'"

This is a common fix for BoringSSL on iOS platforms.