### PR TITLE
Fix BoringSSL-GRPC compilation error for iOS

### DIFF
--- a/ios/BUILD_FIX.md
+++ b/ios/BUILD_FIX.md
@@ -1,12 +1,52 @@
-# gRPC-Core Build Fix
+# iOS Build Fixes
 
-## Problem
+## BoringSSL-GRPC Build Fix (Latest)
+
+### Problem
+The build was failing with this error when compiling BoringSSL-GRPC for iOS:
+```
+unsupported option '-G' for target 'arm64-apple-ios13.0'
+Compile tls_record.cc (arm64)
+```
+
+### Solution Applied
+Added comprehensive build settings for BoringSSL-GRPC in `ios/Podfile` to disable assembly optimizations and prevent the `-G` flag from being passed to the compiler:
+
+1. **Assembly Optimization Disabled**:
+   - `OPENSSL_NO_ASM=1` - Preprocessor definition to disable all assembly code
+   - `OTHER_CFLAGS = '$(inherited) -DOPENSSL_NO_ASM'` - C compiler flag
+   - `OTHER_CPPFLAGS = '$(inherited) -DOPENSSL_NO_ASM'` - C++ compiler flag
+
+2. **Module and Header Map Disabled** (same as gRPC-C++):
+   - `USE_HEADERMAP = NO` - Prevents header map absolute path issues
+   - `CLANG_ENABLE_MODULES = NO` - Disables Clang modules
+
+3. **Bitcode Disabled**:
+   - `ENABLE_BITCODE = NO` - Prevents bitcode-related assembly optimizations
+
+4. **Standard Compiler Settings**:
+   - `CLANG_CXX_LANGUAGE_STANDARD = gnu++17` - GNU C++17 standard
+   - `CLANG_CXX_LIBRARY = libc++` - C++ standard library
+   - `IPHONEOS_DEPLOYMENT_TARGET = 13.0` - iOS 13+ compatibility
+
+### Why This Fix Works
+The `-G` flag is typically used by BoringSSL's build system for assembly optimizations on ARM architectures. By:
+- Setting `OPENSSL_NO_ASM=1` in multiple places (preprocessor, C flags, C++ flags), we ensure all compilation units disable assembly
+- Disabling header maps and modules prevents module-related build issues
+- Disabling bitcode prevents additional optimization passes that might re-enable assembly code
+- Using the same settings as gRPC-C++ ensures consistency across the gRPC stack
+
+---
+
+## gRPC-Core Build Fix
+
+### Problem
 The build was failing with this error:
 ```
 CompileC ... gRPC-Core ... xds_wrr_locality.o ... xds_wrr_locality.cc
 ```
 
-## Solution Applied
+### Solution Applied
 
 ### Changes to `ios/Podfile`:
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -90,9 +90,13 @@ target 'SnapletPjatk' do
           config.build_settings['GCC_WARN_INHIBIT_ALL_WARNINGS'] = 'YES'
           config.build_settings['WARNING_CFLAGS'] = '-Wno-everything'
           config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
-          config.build_settings['OTHER_CFLAGS'] = '$(inherited) -DOPENSSL_NO_ASM'
           config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
           config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'OPENSSL_NO_ASM=1'
+          config.build_settings['OTHER_CFLAGS'] = '$(inherited) -DOPENSSL_NO_ASM'
+          config.build_settings['OTHER_CPPFLAGS'] = '$(inherited) -DOPENSSL_NO_ASM'
+          config.build_settings['USE_HEADERMAP'] = 'NO'
+          config.build_settings['CLANG_ENABLE_MODULES'] = 'NO'
+          config.build_settings['ENABLE_BITCODE'] = 'NO'
         end
 
         # Fix for gRPC-C++ module map path issues


### PR DESCRIPTION
This commit enhances the BoringSSL-GRPC configuration to completely disable assembly optimizations and resolve the "unsupported option '-G' for target 'arm64-apple-ios13.0'" error.

Changes:
- Added OTHER_CPPFLAGS with OPENSSL_NO_ASM for C++ files
- Added USE_HEADERMAP = NO (consistent with gRPC-C++)
- Added CLANG_ENABLE_MODULES = NO (consistent with gRPC-C++)
- Added ENABLE_BITCODE = NO to prevent bitcode assembly optimizations
- Reorganized preprocessor definitions for better clarity
- Updated BUILD_FIX.md with detailed documentation of the fix

The previous fix only set OPENSSL_NO_ASM in OTHER_CFLAGS and preprocessor definitions, but assembly code was still being triggered. This comprehensive approach ensures all compilation units (C and C++) disable assembly, and prevents module/header map issues that could bypass these settings.