### PR TITLE
Document fix for .xcode.env.local path with spaces

### DIFF
--- a/ios/BUILD_FIX.md
+++ b/ios/BUILD_FIX.md
@@ -60,6 +60,32 @@ npm run ios
 - **Module Map Fix**: Disabling modules for gRPC-C++ prevents absolute path issues with modulemap files that reference paths like `/Users/myco/WebstormProjects/...`
 - **No Version Lock**: Allows Firebase to use its required gRPC-Core version (1.62.x) while maintaining build stability
 
+## Common Issues
+
+### .xcode.env.local Path with Spaces
+
+If you see an error like:
+```
+export: `Support/JetBrains/WebStorm2024.3/node/versions/22.11.0/bin/node': not a valid identifier
+```
+
+This means your `ios/.xcode.env.local` file has a NODE_BINARY path with spaces that needs to be quoted.
+
+**Fix:**
+Edit `ios/.xcode.env.local` and ensure the path is quoted:
+```bash
+# Wrong:
+export NODE_BINARY=/Users/myco/Library/Application Support/JetBrains/WebStorm2024.3/node/versions/22.11.0/bin/node
+
+# Correct:
+export NODE_BINARY="/Users/myco/Library/Application Support/JetBrains/WebStorm2024.3/node/versions/22.11.0/bin/node"
+```
+
+Alternatively, delete the `.xcode.env.local` file to use the default node from PATH:
+```bash
+rm ios/.xcode.env.local
+```
+
 ## If Issues Persist
 
 If you still encounter build errors:


### PR DESCRIPTION
Add instructions to fix NODE_BINARY paths containing spaces in .xcode.env.local file. Paths with spaces must be quoted to avoid shell export errors during Xcode build scripts.