### PR TITLE
Update Android Gradle Plugin to 8.1.4 for RN 0.74 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         targetSdkVersion = 34
         ndkVersion = "26.1.10909125"
         kotlinVersion = "1.9.24"
-        androidGradlePluginVersion = "8.3.0"
+        androidGradlePluginVersion = "8.1.4"
     }
     repositories {
         google()


### PR DESCRIPTION
Changed AGP from 8.3.0 to 8.1.4 to resolve serviceOf API errors. React Native 0.74 requires AGP 8.1.x for proper Gradle plugin compatibility.