### PR TITLE
Fix unresolved Gradle plugin reference error

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
…error

React Native 0.74.0's @react-native/gradle-plugin uses internal Gradle APIs that are incompatible with Gradle 8.6. The 'serviceOf' function reference fails to resolve in newer Gradle versions.

Downgrading from Gradle 8.6 to 8.3 (the officially supported version for React Native 0.74) resolves the compilation errors in build.gradle.kts.

Fixes: Unresolved reference: serviceOf at lines 10 and 54