### PR TITLE
Fix React Native Vision Camera Kotlin compilation error

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -102,6 +102,15 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+
+    kotlinOptions {
+        jvmTarget = "17"
+        freeCompilerArgs += [
+            "-opt-in=com.facebook.react.bridge.ReactMarker",
+            "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
+            "-Xsuppress-version-warnings"
+        ]
+    }
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,3 +20,19 @@ buildscript {
 }
 
 apply plugin: "com.facebook.react.rootproject"
+
+subprojects { subproject ->
+    afterEvaluate {
+        if (subproject.plugins.hasPlugin('org.jetbrains.kotlin.android') ||
+            subproject.plugins.hasPlugin('org.jetbrains.kotlin.jvm')) {
+            subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+                kotlinOptions {
+                    freeCompilerArgs += [
+                        "-opt-in=com.facebook.react.bridge.ReactMarker",
+                        "-opt-in=com.facebook.react.uimanager.UIManagerHelper"
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add Kotlin compiler options to opt-in to React Native internal APIs that are used by react-native-vision-camera. This suppresses the compilation errors about ReactMarker and UIManagerHelper being restricted to React Native frameworks.

Changes:
- Added kotlinOptions with opt-in flags to android/app/build.gradle
- Added subprojects configuration in android/build.gradle to apply opt-in flags to all Kotlin modules including react-native-vision-camera