### PR TITLE
Fix Android Gradle build failure

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -7,6 +7,12 @@
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 
+# Java 17 is required for Android Gradle Plugin
+# Uncomment and set the path to your Java 17 installation
+# Windows example: org.gradle.java.home=C\:\\Program Files\\Java\\jdk-17
+# macOS/Linux example: org.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home
+# org.gradle.java.home=
+
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx512m -XX:MaxMetaspaceSize=256m


### PR DESCRIPTION
Android Gradle Plugin requires Java 17 to run. Added commented configuration examples for setting org.gradle.java.home property on both Windows and macOS/Linux systems.