### PR TITLE
Configure Gradle to use Java 19

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -7,11 +7,9 @@
 # For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 
-# Java 17 is required for Android Gradle Plugin
-# Uncomment and set the path to your Java 17 installation
-# Windows example: org.gradle.java.home=C\:\\Program Files\\Java\\jdk-17
-# macOS/Linux example: org.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home
-# org.gradle.java.home=
+# Java 17+ is required for Android Gradle Plugin
+# Set the path to your Java installation (Java 19 in this case)
+org.gradle.java.home=C\:\\Program Files\\Java\\jdk-19
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.


### PR DESCRIPTION
Set org.gradle.java.home to point to the Java 19 installation at C:\Program Files\Java\jdk-19 to resolve the Java 11 error.