### PR TITLE
Fix Gradle build evaluation error in Android project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 apply plugin: "com.facebook.react.rootproject"
 
 subprojects { subproject ->
-    afterEvaluate {
+    subproject.afterEvaluate {
         if (subproject.plugins.hasPlugin('org.jetbrains.kotlin.android') ||
             subproject.plugins.hasPlugin('org.jetbrains.kotlin.jvm')) {
             subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {


### PR DESCRIPTION
Changed afterEvaluate to subproject.afterEvaluate to fix the error: "Cannot run Project.afterEvaluate(Closure) when the project is already evaluated."

This ensures afterEvaluate is called on the correct project instance.