### PR TITLE
Configure daemon logging for client

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,16 +22,23 @@ buildscript {
 apply plugin: "com.facebook.react.rootproject"
 
 subprojects { subproject ->
-    subproject.afterEvaluate {
-        if (subproject.plugins.hasPlugin('org.jetbrains.kotlin.android') ||
-            subproject.plugins.hasPlugin('org.jetbrains.kotlin.jvm')) {
-            subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-                kotlinOptions {
-                    freeCompilerArgs += [
-                        "-opt-in=com.facebook.react.bridge.ReactMarker",
-                        "-opt-in=com.facebook.react.uimanager.UIManagerHelper"
-                    ]
-                }
+    subproject.pluginManager.withPlugin('org.jetbrains.kotlin.android') {
+        subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            kotlinOptions {
+                freeCompilerArgs += [
+                    "-opt-in=com.facebook.react.bridge.ReactMarker",
+                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper"
+                ]
+            }
+        }
+    }
+    subproject.pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
+        subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            kotlinOptions {
+                freeCompilerArgs += [
+                    "-opt-in=com.facebook.react.bridge.ReactMarker",
+                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper"
+                ]
             }
         }
     }


### PR DESCRIPTION
Replace afterEvaluate with pluginManager.withPlugin to avoid "Cannot run Project.afterEvaluate(Closure) when the project is already evaluated" error. This approach works regardless of when the plugin is applied and is the recommended Gradle practice.