### PR TITLE
Fix React Native Vision Camera Kotlin compilation error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,22 +23,26 @@ apply plugin: "com.facebook.react.rootproject"
 
 subprojects { subproject ->
     subproject.pluginManager.withPlugin('org.jetbrains.kotlin.android') {
-        subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-            kotlinOptions {
-                freeCompilerArgs += [
-                    "-opt-in=com.facebook.react.bridge.ReactMarker",
-                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper"
-                ]
+        subproject.afterEvaluate {
+            subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+                kotlinOptions {
+                    freeCompilerArgs += [
+                        "-opt-in=com.facebook.react.bridge.ReactMarker",
+                        "-opt-in=com.facebook.react.uimanager.UIManagerHelper"
+                    ]
+                }
             }
         }
     }
     subproject.pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
-        subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-            kotlinOptions {
-                freeCompilerArgs += [
-                    "-opt-in=com.facebook.react.bridge.ReactMarker",
-                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper"
-                ]
+        subproject.afterEvaluate {
+            subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+                kotlinOptions {
+                    freeCompilerArgs += [
+                        "-opt-in=com.facebook.react.bridge.ReactMarker",
+                        "-opt-in=com.facebook.react.uimanager.UIManagerHelper"
+                    ]
+                }
             }
         }
     }


### PR DESCRIPTION
The previous fix removed afterEvaluate entirely, which caused Kotlin compilation tasks to be configured before they were created. This fix uses afterEvaluate inside the pluginManager.withPlugin callback to ensure tasks exist when we configure them.

This approach:
- Only applies when Kotlin plugin is present (via withPlugin)
- Waits for task creation (via afterEvaluate)
- Avoids "already evaluated" error by scoping afterEvaluate to subprojects