### PR TITLE
Fix Gradle afterEvaluate error in Android build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,26 +23,22 @@ apply plugin: "com.facebook.react.rootproject"
 
 subprojects { subproject ->
     subproject.pluginManager.withPlugin('org.jetbrains.kotlin.android') {
-        subproject.afterEvaluate {
-            subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-                kotlinOptions {
-                    freeCompilerArgs += [
-                        "-opt-in=com.facebook.react.bridge.ReactMarker",
-                        "-opt-in=com.facebook.react.uimanager.UIManagerHelper"
-                    ]
-                }
+        subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            kotlinOptions {
+                freeCompilerArgs += [
+                    "-opt-in=com.facebook.react.bridge.ReactMarker",
+                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper"
+                ]
             }
         }
     }
     subproject.pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
-        subproject.afterEvaluate {
-            subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-                kotlinOptions {
-                    freeCompilerArgs += [
-                        "-opt-in=com.facebook.react.bridge.ReactMarker",
-                        "-opt-in=com.facebook.react.uimanager.UIManagerHelper"
-                    ]
-                }
+        subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            kotlinOptions {
+                freeCompilerArgs += [
+                    "-opt-in=com.facebook.react.bridge.ReactMarker",
+                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper"
+                ]
             }
         }
     }


### PR DESCRIPTION
The afterEvaluate calls inside withPlugin callbacks were causing 'Cannot run Project.afterEvaluate when the project is already evaluated' errors. Since withPlugin already ensures the plugin is applied and tasks.withType().configureEach() provides lazy configuration, the afterEvaluate wrappers are unnecessary and cause timing issues.