### PR TITLE
Fix Kotlin compilation error in Vision Camera

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -108,6 +108,7 @@ android {
         freeCompilerArgs += [
             "-opt-in=com.facebook.react.bridge.ReactMarker",
             "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
+            "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI",
             "-Xsuppress-version-warnings"
         ]
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,8 @@ subprojects { subproject ->
             kotlinOptions {
                 freeCompilerArgs += [
                     "-opt-in=com.facebook.react.bridge.ReactMarker",
-                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper"
+                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
+                    "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI"
                 ]
             }
         }
@@ -37,7 +38,8 @@ subprojects { subproject ->
             kotlinOptions {
                 freeCompilerArgs += [
                     "-opt-in=com.facebook.react.bridge.ReactMarker",
-                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper"
+                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
+                    "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI"
                 ]
             }
         }


### PR DESCRIPTION
…compilation

Added -opt-in=com.facebook.react.internal.ReactNativeInternalAPI compiler flag to allow react-native-vision-camera to use React Native framework internal APIs. This resolves the compilation errors where the Kotlin compiler was treating internal API usage warnings as errors.