### PR TITLE
Fix React Native Screens build process

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,25 +22,17 @@ buildscript {
 apply plugin: "com.facebook.react.rootproject"
 
 subprojects { subproject ->
-    subproject.pluginManager.withPlugin('org.jetbrains.kotlin.android') {
-        subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-            kotlinOptions {
-                freeCompilerArgs += [
-                    "-opt-in=com.facebook.react.bridge.ReactMarker",
-                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
-                    "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI"
-                ]
-            }
-        }
-    }
-    subproject.pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
-        subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-            kotlinOptions {
-                freeCompilerArgs += [
-                    "-opt-in=com.facebook.react.bridge.ReactMarker",
-                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
-                    "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI"
-                ]
+    subproject.afterEvaluate {
+        if (subproject.plugins.hasPlugin('org.jetbrains.kotlin.android') ||
+            subproject.plugins.hasPlugin('org.jetbrains.kotlin.jvm')) {
+            subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+                kotlinOptions {
+                    freeCompilerArgs += [
+                        "-opt-in=com.facebook.react.bridge.ReactMarker",
+                        "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
+                        "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI"
+                    ]
+                }
             }
         }
     }


### PR DESCRIPTION
…ects

The previous approach using withPlugin callbacks had timing issues because the callbacks execute asynchronously when plugins are detected, which may occur after Kotlin compilation tasks are already configured. This caused the compiler options (including opt-in annotations) to not be applied properly, resulting in compilation failures for react-native-vision-camera.

This fix uses afterEvaluate directly on each subproject, which ensures:
1. All plugins are applied to the subproject
2. The build script is fully evaluated
3. We can then safely check for Kotlin plugins and configure compiler options
4. Configuration happens before task execution but after task creation

This resolves the vision-camera Kotlin compilation error.