### PR TITLE
Fix Gradle afterEvaluate error in Android build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 apply plugin: "com.facebook.react.rootproject"
 
 subprojects { subproject ->
-    subproject.afterEvaluate {
+    def configureKotlinOptions = {
         if (subproject.plugins.hasPlugin('org.jetbrains.kotlin.android') ||
             subproject.plugins.hasPlugin('org.jetbrains.kotlin.jvm')) {
             subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
@@ -34,6 +34,14 @@ subprojects { subproject ->
                     ]
                 }
             }
+        }
+    }
+
+    if (subproject.state.executed) {
+        configureKotlinOptions()
+    } else {
+        subproject.afterEvaluate {
+            configureKotlinOptions()
         }
     }
 }


### PR DESCRIPTION
The previous fix attempted to use afterEvaluate in a subprojects block, but this fails when some projects are already evaluated. This commit fixes the issue by:

- Extracting the Kotlin configuration logic into a closure
- Checking if the project is already evaluated using state.executed
- Applying configuration immediately for evaluated projects
- Using afterEvaluate only for not-yet-evaluated projects

This ensures the Kotlin compiler options are applied correctly regardless of when the subprojects are evaluated.