### PR TITLE
Use pluginManager.withPlugin for safer Kotlin configuration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,26 +22,27 @@ buildscript {
 apply plugin: "com.facebook.react.rootproject"
 
 subprojects { subproject ->
-    def configureKotlinOptions = {
-        if (subproject.plugins.hasPlugin('org.jetbrains.kotlin.android') ||
-            subproject.plugins.hasPlugin('org.jetbrains.kotlin.jvm')) {
-            subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-                kotlinOptions {
-                    freeCompilerArgs += [
-                        "-opt-in=com.facebook.react.bridge.ReactMarker",
-                        "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
-                        "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI"
-                    ]
-                }
+    subproject.pluginManager.withPlugin('org.jetbrains.kotlin.android') {
+        subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            kotlinOptions {
+                freeCompilerArgs += [
+                    "-opt-in=com.facebook.react.bridge.ReactMarker",
+                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
+                    "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI"
+                ]
             }
         }
     }
 
-    if (subproject.state.executed) {
-        configureKotlinOptions()
-    } else {
-        subproject.afterEvaluate {
-            configureKotlinOptions()
+    subproject.pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
+        subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            kotlinOptions {
+                freeCompilerArgs += [
+                    "-opt-in=com.facebook.react.bridge.ReactMarker",
+                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
+                    "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI"
+                ]
+            }
         }
     }
 }


### PR DESCRIPTION
Replace the state.executed check with Gradle's pluginManager.withPlugin API, which is the proper way to apply configuration when a plugin is detected. This approach:

- Automatically handles timing - applies immediately if plugin exists, or waits if not yet applied
- Avoids afterEvaluate timing issues entirely
- Follows Gradle best practices for plugin-dependent configuration
- Eliminates the "Cannot run afterEvaluate when project is evaluated" error

The configuration now reliably applies Kotlin compiler opt-ins for React Native internal APIs to all subprojects using Kotlin.