### PR TITLE
Fix Vision Camera API framework compatibility issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,8 +28,10 @@ subprojects { subproject ->
                 freeCompilerArgs += [
                     "-opt-in=com.facebook.react.bridge.ReactMarker",
                     "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
-                    "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI"
+                    "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI",
+                    "-opt-in=com.facebook.react.bridge.FrameworkAPI"
                 ]
+                allWarningsAsErrors = false
             }
         }
     }
@@ -40,8 +42,10 @@ subprojects { subproject ->
                 freeCompilerArgs += [
                     "-opt-in=com.facebook.react.bridge.ReactMarker",
                     "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
-                    "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI"
+                    "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI",
+                    "-opt-in=com.facebook.react.bridge.FrameworkAPI"
                 ]
+                allWarningsAsErrors = false
             }
         }
     }


### PR DESCRIPTION
Add opt-in flag for React Native FrameworkAPI to suppress the warning: "This API is provided only for React Native frameworks and not intended for general users"

Changes:
- Added -opt-in=com.facebook.react.bridge.FrameworkAPI to Kotlin compiler args
- Set allWarningsAsErrors = false to prevent warnings from failing builds

This addresses the VisionCameraProxy.kt:31:79 warning when using react-native-vision-camera v3.9.0 with React Native 0.74.0