### PR TITLE
Fix Android debug build assembly

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,10 +26,11 @@ subprojects { subproject ->
         subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
             kotlinOptions {
                 freeCompilerArgs += [
-                    "-opt-in=com.facebook.react.bridge.ReactMarker",
-                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
-                    "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI",
-                    "-opt-in=com.facebook.react.bridge.FrameworkAPI"
+                    "-opt-in=kotlin.RequiresOptIn",
+                    "-Xopt-in=com.facebook.react.bridge.ReactMarker",
+                    "-Xopt-in=com.facebook.react.uimanager.UIManagerHelper",
+                    "-Xopt-in=com.facebook.react.internal.ReactNativeInternalAPI",
+                    "-Xopt-in=com.facebook.react.bridge.FrameworkAPI"
                 ]
                 allWarningsAsErrors = false
             }
@@ -40,10 +41,11 @@ subprojects { subproject ->
         subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
             kotlinOptions {
                 freeCompilerArgs += [
-                    "-opt-in=com.facebook.react.bridge.ReactMarker",
-                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
-                    "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI",
-                    "-opt-in=com.facebook.react.bridge.FrameworkAPI"
+                    "-opt-in=kotlin.RequiresOptIn",
+                    "-Xopt-in=com.facebook.react.bridge.ReactMarker",
+                    "-Xopt-in=com.facebook.react.uimanager.UIManagerHelper",
+                    "-Xopt-in=com.facebook.react.internal.ReactNativeInternalAPI",
+                    "-Xopt-in=com.facebook.react.bridge.FrameworkAPI"
                 ]
                 allWarningsAsErrors = false
             }


### PR DESCRIPTION
Changed Kotlin compiler opt-in flags from -opt-in to -Xopt-in to forcefully suppress FrameworkAPI errors. The standard -opt-in flags were not working because the opt-in requirement markers (ReactNativeInternalAPI, FrameworkAPI) are unresolved in React Native 0.74.

Changes:
- Replaced -opt-in with -Xopt-in for all React Native internal API markers
- Added -opt-in=kotlin.RequiresOptIn for proper opt-in support
- This addresses react-native-vision-camera 3.9.0 compilation failures with RN 0.74

The -Xopt-in flag is more forceful and works even when annotation classes are not properly exported or resolvable.

Related issues:
- mrousavy/react-native-vision-camera#2851
- mrousavy/react-native-vision-camera#2783