### PR TITLE
Fix Android debug build assembly

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,10 +27,10 @@ subprojects { subproject ->
             kotlinOptions {
                 freeCompilerArgs += [
                     "-opt-in=kotlin.RequiresOptIn",
-                    "-Xopt-in=com.facebook.react.bridge.ReactMarker",
-                    "-Xopt-in=com.facebook.react.uimanager.UIManagerHelper",
-                    "-Xopt-in=com.facebook.react.internal.ReactNativeInternalAPI",
-                    "-Xopt-in=com.facebook.react.bridge.FrameworkAPI"
+                    "-opt-in=com.facebook.react.bridge.ReactMarker",
+                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
+                    "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI",
+                    "-opt-in=com.facebook.react.bridge.FrameworkAPI"
                 ]
                 allWarningsAsErrors = false
             }
@@ -42,10 +42,10 @@ subprojects { subproject ->
             kotlinOptions {
                 freeCompilerArgs += [
                     "-opt-in=kotlin.RequiresOptIn",
-                    "-Xopt-in=com.facebook.react.bridge.ReactMarker",
-                    "-Xopt-in=com.facebook.react.uimanager.UIManagerHelper",
-                    "-Xopt-in=com.facebook.react.internal.ReactNativeInternalAPI",
-                    "-Xopt-in=com.facebook.react.bridge.FrameworkAPI"
+                    "-opt-in=com.facebook.react.bridge.ReactMarker",
+                    "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
+                    "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI",
+                    "-opt-in=com.facebook.react.bridge.FrameworkAPI"
                 ]
                 allWarningsAsErrors = false
             }


### PR DESCRIPTION
Changed deprecated -Xopt-in flags to -opt-in in android/build.gradle to resolve React Native Vision Camera compilation errors. This fixes the "This API is provided only for React Native frameworks" errors that were preventing the debug build from completing.