### PR TITLE
Add specific Kotlin compiler config for react-native-vision-camera

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,24 @@ buildscript {
 apply plugin: "com.facebook.react.rootproject"
 
 subprojects { subproject ->
+    afterEvaluate {
+        if (subproject.name == 'react-native-vision-camera') {
+            subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach { task ->
+                task.kotlinOptions {
+                    freeCompilerArgs += [
+                        "-opt-in=kotlin.RequiresOptIn",
+                        "-opt-in=com.facebook.react.bridge.ReactMarker",
+                        "-opt-in=com.facebook.react.uimanager.UIManagerHelper",
+                        "-opt-in=com.facebook.react.internal.ReactNativeInternalAPI",
+                        "-opt-in=com.facebook.react.bridge.FrameworkAPI",
+                        "-Xsuppress-version-warnings"
+                    ]
+                    allWarningsAsErrors = false
+                }
+            }
+        }
+    }
+
     subproject.pluginManager.withPlugin('org.jetbrains.kotlin.android') {
         subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
             kotlinOptions {


### PR DESCRIPTION
Added afterEvaluate block to specifically target react-native-vision-camera with additional -Xsuppress-version-warnings flag to handle React Native framework internal API usage errors. This should resolve the compilation failures related to VisionCameraProxy.kt using framework-only APIs.