### PR TITLE
Fix Gradle afterEvaluate syntax error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 apply plugin: "com.facebook.react.rootproject"
 
 subprojects { subproject ->
-    afterEvaluate {
+    subproject.afterEvaluate {
         if (subproject.name == 'react-native-vision-camera') {
             subproject.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach { task ->
                 task.kotlinOptions {


### PR DESCRIPTION
Use subproject.afterEvaluate instead of afterEvaluate to properly apply configuration to each subproject rather than the root project.