### PR TITLE
Fix Gradle afterEvaluate error in Android build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,9 +21,9 @@ buildscript {
 
 apply plugin: "com.facebook.react.rootproject"
 
-allprojects {
+subprojects {
     afterEvaluate { project ->
-        // Configure Kotlin compilation for all projects
+        // Configure Kotlin compilation for all subprojects
         project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach { task ->
             task.kotlinOptions {
                 def baseArgs = [


### PR DESCRIPTION
…jects

Changed allprojects to subprojects in root build.gradle to resolve the "Cannot run Project.afterEvaluate(Closure) when the project is already evaluated" error. The root project doesn't need Kotlin compilation configuration, only the Android subprojects (app and native modules) do.