### PR TITLE
Fix Android 16 KB alignment warning

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -103,6 +103,12 @@ android {
         }
     }
 
+    packaging {
+        jniLibs {
+            useLegacyPackaging = false
+        }
+    }
+
     kotlinOptions {
         jvmTarget = "17"
         freeCompilerArgs += [


### PR DESCRIPTION
Add packaging configuration to support 16 KB page size alignment for native libraries. This resolves the compatibility warning for newer Android devices (Android 15+) that use 16 KB page sizes.

Changes:
- Add packaging block with jniLibs.useLegacyPackaging = false to android/app/build.gradle
- This ensures all native libraries are properly aligned at 16 KB boundaries