### PR TITLE
Fix startup issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ npm run type-check
 
 ## Troubleshooting
 
+### Startup Issues - "Unable to load script" Error
+
+If you see a red error screen when starting the app, see **[STARTUP_TROUBLESHOOTING.md](STARTUP_TROUBLESHOOTING.md)** for detailed solutions.
+
+**Quick fix:**
+1. Start Metro bundler first: `npm start`
+2. Wait for Metro to load
+3. In a new terminal, run: `npm run android`
+
 ### Android Vision Camera Build Issues
 
 If you encounter compilation errors related to `react-native-vision-camera`:

--- a/STARTUP_TROUBLESHOOTING.md
+++ b/STARTUP_TROUBLESHOOTING.md
@@ -1,0 +1,117 @@
+# Startup Troubleshooting Guide
+
+## Common Issue: "Unable to load script" Error
+
+If you see a red error screen with the message:
+```
+Unable to load script. Make sure you're either running Metro (run 'npx react-native start')
+or that your bundle 'index.android.bundle' is packaged correctly for release.
+```
+
+This means the app cannot find the JavaScript bundle. Follow these steps to fix it:
+
+## Solution: Proper Startup Sequence
+
+### Step 1: Clean Previous Builds
+```bash
+# Clean Android build
+cd android
+./gradlew clean
+cd ..
+
+# Or use the npm script
+npm run android:clean
+```
+
+### Step 2: Start Metro Bundler First
+**IMPORTANT**: You must start Metro bundler BEFORE running the app.
+
+```bash
+# Start Metro bundler in one terminal
+npm start
+
+# Or with cache reset if you have issues
+npm run start:reset
+```
+
+Wait until you see:
+```
+Welcome to Metro v...
+```
+
+### Step 3: Run the App (in a new terminal)
+**Only after Metro is running**, run the app:
+
+```bash
+# In a NEW terminal window/tab
+npm run android
+```
+
+## Additional Fixes Applied
+
+### 1. Network Security Configuration
+Added network security config to allow Metro bundler connection on localhost.
+- File: `android/app/src/main/res/xml/network_security_config.xml`
+- Allows cleartext traffic to localhost and emulator IPs
+
+### 2. Gradle Configuration
+Fixed platform-specific Java path in `gradle.properties`:
+- Removed Windows-specific `org.gradle.java.home` setting
+- Now uses system default Java installation
+
+## Platform-Specific Notes
+
+### Linux/macOS
+The fixes applied should work out of the box.
+
+### Windows
+If you're on Windows, you may need to uncomment and set the Java path in `android/gradle.properties`:
+```properties
+org.gradle.java.home=C\:\\Program Files\\Java\\jdk-19
+```
+(Adjust the path to match your Java installation)
+
+## Still Having Issues?
+
+### Check Metro Bundler is Running
+- Metro should be running on http://localhost:8081
+- Open http://localhost:8081/status in your browser
+- You should see: `{"packager":"running"}`
+
+### Check Device/Emulator Connection
+```bash
+# List connected devices
+adb devices
+
+# If your device shows "unauthorized", accept the prompt on your device
+```
+
+### Reset Everything
+```bash
+# Kill Metro bundler
+# Press Ctrl+C in the Metro terminal
+
+# Clean everything
+npm run android:clean
+watchman watch-del-all  # If you have watchman installed
+rm -rf node_modules
+npm install
+
+# Start fresh
+npm start
+# Then in new terminal:
+npm run android
+```
+
+## Development Workflow
+
+Always use this sequence:
+1. **Terminal 1**: `npm start` (Metro bundler)
+2. **Terminal 2**: `npm run android` (Build and run app)
+3. Keep Terminal 1 running while developing
+
+## Debugging Tips
+
+- Press `R` twice in Metro terminal to reload the app
+- Shake your device or press `Cmd+M` (Mac) / `Ctrl+M` (Windows/Linux) to open dev menu
+- Enable "Fast Refresh" in dev menu for automatic reloading on code changes

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,9 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:networkSecurityConfig="@xml/network_security_config"
+      android:usesCleartextTraffic="true">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Allow cleartext traffic to localhost for Metro bundler in debug builds -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">10.0.3.2</domain>
+    </domain-config>
+</network-security-config>

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -9,7 +9,8 @@
 
 # Java 17+ is required for Android Gradle Plugin
 # Set the path to your Java installation (Java 19 in this case)
-org.gradle.java.home=C\:\\Program Files\\Java\\jdk-19
+# Note: Commented out Windows-specific path - let Gradle use system Java
+# org.gradle.java.home=C\:\\Program Files\\Java\\jdk-19
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.


### PR DESCRIPTION
This commit resolves the "Unable to load script" error that occurs when starting the React Native app.

Changes:
- Fixed gradle.properties: Commented out Windows-specific Java path that doesn't work on Linux/macOS
- Added network security config: Allow cleartext traffic to localhost for Metro bundler connection
- Updated AndroidManifest.xml: Reference network security config to enable Metro connection
- Created STARTUP_TROUBLESHOOTING.md: Comprehensive guide for startup issues and proper development workflow
- Updated README.md: Added quick reference to startup troubleshooting

Root causes fixed:
1. Platform-specific configuration (Windows Java path) breaking Linux builds
2. Network security restrictions preventing Metro bundler connection on Android API 28+
3. Missing documentation on proper startup sequence (Metro first, then app)

The app should now start correctly when following the proper sequence:
1. npm start (Metro bundler)
2. npm run android (in new terminal)