### PR TITLE
Fix Java version configuration for cross-platform compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ snaplet-pjatk/
 
 - **Windows 11**: See [WINDOWS_SETUP.md](WINDOWS_SETUP.md) for detailed Windows 11 setup instructions
 - **macOS/Linux**: Follow the instructions below
+- **Java Configuration**: The project requires Java 17+. See [STARTUP_TROUBLESHOOTING.md](STARTUP_TROUBLESHOOTING.md#platform-specific-notes) for platform-specific Java configuration
 
 ### Installation
 
@@ -129,6 +130,20 @@ If you see a red error screen when starting the app, see **[STARTUP_TROUBLESHOOT
 1. Start Metro bundler first: `npm start`
 2. Wait for Metro to load
 3. In a new terminal, run: `npm run android`
+
+### Java Version Error - "Requires Java 17"
+
+If you see `Android Gradle plugin requires Java 17 to run. You are currently using Java 11`:
+
+**Windows:**
+- The project is pre-configured for Java 19 at `C:\Program Files\Java\jdk-19`
+- If your Java is elsewhere, update `android/gradle.properties` line 13
+
+**Linux/macOS:**
+- Comment out line 13 in `android/gradle.properties`
+- Ensure your system Java is version 17+
+
+See **[STARTUP_TROUBLESHOOTING.md](STARTUP_TROUBLESHOOTING.md#platform-specific-notes)** for detailed instructions.
 
 ### Android Vision Camera Build Issues
 

--- a/STARTUP_TROUBLESHOOTING.md
+++ b/STARTUP_TROUBLESHOOTING.md
@@ -55,21 +55,42 @@ Added network security config to allow Metro bundler connection on localhost.
 - Allows cleartext traffic to localhost and emulator IPs
 
 ### 2. Gradle Configuration
-Fixed platform-specific Java path in `gradle.properties`:
-- Removed Windows-specific `org.gradle.java.home` setting
-- Now uses system default Java installation
+Configured Java path in `gradle.properties` for cross-platform compatibility:
+- Windows: Uses explicit path to Java 19 (`C:\Program Files\Java\jdk-19`)
+- Linux/macOS: Users should comment out the path to use system Java
+- See "Platform-Specific Notes" below for configuration instructions
 
 ## Platform-Specific Notes
 
-### Linux/macOS
-The fixes applied should work out of the box.
-
 ### Windows
-If you're on Windows, you may need to uncomment and set the Java path in `android/gradle.properties`:
+**IMPORTANT**: The project is configured for Windows by default with Java 19 path set in `android/gradle.properties`:
 ```properties
 org.gradle.java.home=C\:\\Program Files\\Java\\jdk-19
 ```
-(Adjust the path to match your Java installation)
+
+**If you have Java installed in a different location:**
+1. Open `android/gradle.properties`
+2. Update line 13 with your Java 17+ installation path
+3. Example: `org.gradle.java.home=C\:\\Program Files\\Java\\jdk-17`
+
+**If you don't have Java 17+:**
+- Download and install JDK 17 or higher from [Oracle](https://www.oracle.com/java/technologies/downloads/) or [Adoptium](https://adoptium.net/)
+- Update the path in `android/gradle.properties` accordingly
+
+### Linux/macOS
+**IMPORTANT**: You need to comment out the Windows Java path:
+1. Open `android/gradle.properties`
+2. Comment out line 13:
+```properties
+# org.gradle.java.home=C\:\\Program Files\\Java\\jdk-19
+```
+3. Gradle will automatically use your system Java installation
+
+**Checking your Java version:**
+```bash
+java -version
+# Should show version 17 or higher
+```
 
 ## Still Having Issues?
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -8,9 +8,9 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 
 # Java 17+ is required for Android Gradle Plugin
-# Set the path to your Java installation (Java 19 in this case)
-# Note: Commented out Windows-specific path - let Gradle use system Java
-# org.gradle.java.home=C\:\\Program Files\\Java\\jdk-19
+# WINDOWS: Uncomment and set the path to your Java 17+ installation
+# LINUX/macOS: Comment this line out - Gradle will use system Java
+org.gradle.java.home=C\:\\Program Files\\Java\\jdk-19
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.


### PR DESCRIPTION
This commit addresses the "Android Gradle plugin requires Java 17" error on Windows while maintaining Linux/macOS compatibility.

Changes:
- Restored org.gradle.java.home configuration in gradle.properties for Windows users
- Added clear platform-specific instructions in gradle.properties comments
- Updated STARTUP_TROUBLESHOOTING.md with detailed Java configuration guide for both platforms
- Updated README.md with Java version troubleshooting section

Root cause:
- Windows users need explicit Java path due to system Java being older version (11)
- Linux/macOS users should use system Java by commenting out the path
- Project now defaults to Windows configuration (Java 19 path) with instructions for other platforms

Platform-specific setup:
- Windows: Uses C:\Program Files\Java\jdk-19 (or user's Java 17+ location)
- Linux/macOS: Should comment out org.gradle.java.home to use system Java

This ensures the project can be built on both platforms with minimal configuration.