### PR TITLE
fix: Remove non-existent figma directory reference from webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const appDirectory = path.resolve(__dirname);
 
@@ -52,14 +51,6 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: path.resolve(appDirectory, 'public/index.html'),
-    }),
-    new CopyWebpackPlugin({
-      patterns: [
-        {
-          from: path.resolve(appDirectory, 'figma'),
-          to: path.resolve(appDirectory, 'dist/figma'),
-        },
-      ],
     }),
   ],
   devServer: {


### PR DESCRIPTION
The webpack build was failing because CopyWebpackPlugin was trying to copy a figma directory that doesn't exist. Removed the plugin configuration to fix the build error.