### PR TITLE
Configure webpack dev server for subdirectory deployment

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,9 +57,12 @@ module.exports = {
   devServer: {
     static: {
       directory: path.join(__dirname, 'public'),
+      publicPath: '/snaplet-pjatk-project/',
     },
     compress: true,
     port: 8080,
-    historyApiFallback: true,
+    historyApiFallback: {
+      index: '/snaplet-pjatk-project/index.html',
+    },
   },
 };


### PR DESCRIPTION
## Summary
Updated webpack dev server configuration to support deployment under a subdirectory path (`/snaplet-pjatk-project/`) instead of the root domain.

## Changes
- Added `publicPath: '/snaplet-pjatk-project/'` to the static directory configuration to serve assets from the correct subdirectory
- Changed `historyApiFallback` from a boolean to an object configuration that explicitly sets the index file path to `/snaplet-pjatk-project/index.html`

## Details
These changes ensure that:
- Static assets are correctly resolved when the application is served from a subdirectory
- Client-side routing (history API) properly falls back to the index.html file located at the subdirectory path
- The development server behavior matches the production deployment structure

https://claude.ai/code/session_01CBUXHU9APrnSmBC3wDtkvC