### PR TITLE
Fix broken images by configuring devServer to serve at correct path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,9 +57,12 @@ module.exports = {
   devServer: {
     static: {
       directory: path.join(__dirname, 'public'),
+      publicPath: '/snaplet-pjatk-project/',
     },
     compress: true,
     port: 8080,
-    historyApiFallback: true,
+    historyApiFallback: {
+      index: '/snaplet-pjatk-project/index.html',
+    },
   },
 };


### PR DESCRIPTION
The webpack devServer was serving static files at root (/) but image paths expected /snaplet-pjatk-project/ prefix. Updated devServer config to serve static files at the correct publicPath and configure historyApiFallback.