### PR TITLE
fix: Fix infinite loading screen issue

### DIFF
--- a/index.web.js
+++ b/index.web.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { useUserStore } from './src/store/userStore';
 
 // Import screens
 import LoginScreen from './src/screens/LoginScreen';
@@ -11,25 +12,7 @@ import MessagesScreen from './src/screens/MessagesScreen';
 import ProfileScreen from './src/screens/ProfileScreen';
 import CameraScreen from './src/screens/CameraScreen';
 import PostDetailScreen from './src/screens/PostDetailScreen';
-
-// Main App component with routing
-const App = () => {
-  return (
-    <Router basename="/snaplet-pjatk-project">
-      <Routes>
-        <Route path="/" element={<Navigate to="/login" replace />} />
-        <Route path="/login" element={<LoginScreen />} />
-        <Route path="/register" element={<RegisterScreen />} />
-        <Route path="/home" element={<HomeScreen />} />
-        <Route path="/settings" element={<SettingsScreen />} />
-        <Route path="/messages" element={<MessagesScreen />} />
-        <Route path="/profile" element={<ProfileScreen />} />
-        <Route path="/camera" element={<CameraScreen />} />
-        <Route path="/post/:id" element={<PostDetailScreen />} />
-      </Routes>
-    </Router>
-  );
-};
+import WelcomeScreen from './src/screens/WelcomeScreen';
 
 // Remove loading screen helper
 const removeLoadingScreen = () => {
@@ -42,14 +25,77 @@ const removeLoadingScreen = () => {
   }
 };
 
-// Render app
-const container = document.getElementById('root');
-const root = createRoot(container);
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+// Protected Route component
+const ProtectedRoute = ({ children }) => {
+  const { isAuthenticated, isLoading } = useUserStore();
 
-// Remove loading screen after React mounts
-removeLoadingScreen();
+  if (isLoading) {
+    return null; // Keep showing the HTML loading screen
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+};
+
+// Main App component with routing
+const App = () => {
+  const { initialize, isLoading } = useUserStore();
+  const [appReady, setAppReady] = useState(false);
+
+  useEffect(() => {
+    // Initialize auth state
+    const unsubscribe = initialize();
+
+    // Mark app as ready after a short delay to ensure state is settled
+    const timeout = setTimeout(() => {
+      setAppReady(true);
+      removeLoadingScreen();
+    }, 100);
+
+    return () => {
+      unsubscribe();
+      clearTimeout(timeout);
+    };
+  }, [initialize]);
+
+  // Keep loading screen visible until app is ready
+  useEffect(() => {
+    if (appReady && !isLoading) {
+      removeLoadingScreen();
+    }
+  }, [appReady, isLoading]);
+
+  return (
+    <Router basename="/snaplet-pjatk-project">
+      <Routes>
+        <Route path="/" element={<Navigate to="/login" replace />} />
+        <Route path="/welcome" element={<WelcomeScreen />} />
+        <Route path="/login" element={<LoginScreen />} />
+        <Route path="/register" element={<RegisterScreen />} />
+        <Route path="/home" element={<ProtectedRoute><HomeScreen /></ProtectedRoute>} />
+        <Route path="/settings" element={<ProtectedRoute><SettingsScreen /></ProtectedRoute>} />
+        <Route path="/messages" element={<ProtectedRoute><MessagesScreen /></ProtectedRoute>} />
+        <Route path="/profile" element={<ProtectedRoute><ProfileScreen /></ProtectedRoute>} />
+        <Route path="/camera" element={<ProtectedRoute><CameraScreen /></ProtectedRoute>} />
+        <Route path="/post/:id" element={<ProtectedRoute><PostDetailScreen /></ProtectedRoute>} />
+      </Routes>
+    </Router>
+  );
+};
+
+// Render app with error handling
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+} else {
+  console.error('Root element not found');
+  removeLoadingScreen();
+}


### PR DESCRIPTION
- Add fallback timeout in userStore.initialize() to handle cases where Firebase auth state listener never fires (e.g., misconfigured Firebase)
- Update index.web.js to properly initialize auth and remove loading screen
- Add ProtectedRoute component for authenticated routes
- Add WelcomeScreen to web routing