### PR TITLE
fix: Overhaul web UI with emoji icons and consistent styling

### DIFF
--- a/src/components/BottomNav.js
+++ b/src/components/BottomNav.js
@@ -1,35 +1,88 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 
-const BottomNav = ({ active }) => {
+const navItems = [
+  { path: '/home', emoji: '🏠', label: 'Home' },
+  { path: '/messages', emoji: '💬', label: 'Messages' },
+  { path: '/camera', emoji: '📷', label: 'Camera' },
+  { path: '/profile', emoji: '👤', label: 'Profile' },
+  { path: '/settings', emoji: '⚙️', label: 'Settings' },
+];
+
+const BottomNav = () => {
   const navigate = useNavigate();
+  const location = useLocation();
 
   return (
-    <div className="frame-6-54" style={{position: 'absolute', bottom: 0}}>
-      <div className="user-user-01" onClick={() => navigate('/profile')} style={{cursor: 'pointer'}}>
-        <img src="/snaplet-pjatk-project/figma/images/vector-56.svg" className="vector-56" alt="profile" />
-      </div>
-      <div className="user-users" onClick={() => navigate('/messages')} style={{cursor: 'pointer'}}>
-        <img src="/snaplet-pjatk-project/figma/images/vector-58.svg" className="vector-58" alt="messages" />
-      </div>
-      <img
-        src="/snaplet-pjatk-project/figma/images/rectangle-59.png"
-        className="rectangle-59"
-        alt="home"
-        onClick={() => navigate('/home')}
-        style={{cursor: 'pointer'}}
-      />
-      <div className="node-60" onClick={() => navigate('/settings')} style={{cursor: 'pointer'}}>
-        <img src="/snaplet-pjatk-project/figma/images/vector-61.svg" className="vector-61" alt="settings" />
-      </div>
-      <div className="calendar-logo-62">
-        <div className="rectangle-97-63"></div>
-        <div className="rectangle-100-64"></div>
-        <div className="rectangle-99-65"></div>
-        <div className="rectangle-98-66"></div>
-      </div>
-    </div>
+    <nav style={styles.container}>
+      {navItems.map((item) => {
+        const isActive = location.pathname === item.path;
+        return (
+          <button
+            key={item.path}
+            onClick={() => navigate(item.path)}
+            style={{
+              ...styles.navItem,
+              ...(isActive ? styles.navItemActive : {}),
+            }}
+          >
+            <span style={styles.emoji}>{item.emoji}</span>
+            <span style={{
+              ...styles.label,
+              ...(isActive ? styles.labelActive : {}),
+            }}>
+              {item.label}
+            </span>
+          </button>
+        );
+      })}
+    </nav>
   );
+};
+
+const styles = {
+  container: {
+    position: 'fixed',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    display: 'flex',
+    justifyContent: 'space-around',
+    alignItems: 'center',
+    backgroundColor: '#FFFFFF',
+    borderTop: '1px solid #E0E0E0',
+    padding: '8px 0 12px 0',
+    zIndex: 1000,
+  },
+  navItem: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    padding: '4px 12px',
+    borderRadius: '8px',
+    transition: 'background-color 0.2s',
+    minWidth: '60px',
+  },
+  navItemActive: {
+    backgroundColor: '#F5E6D3',
+  },
+  emoji: {
+    fontSize: '24px',
+    marginBottom: '2px',
+  },
+  label: {
+    fontSize: '11px',
+    color: '#666666',
+    fontWeight: '500',
+  },
+  labelActive: {
+    color: '#000000',
+    fontWeight: '600',
+  },
 };
 
 export default BottomNav;

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -100,15 +100,12 @@ const HomeScreen = () => {
   };
 
   return (
-    <div className="screen home-screen" onScroll={handleScroll} style={{ overflowY: 'auto', height: '100vh' }}>
-      {/* Header with settings */}
-      <div className="home-header">
-        <h1 style={{ fontSize: '20px', fontWeight: '600', margin: 0 }}>Snaplet</h1>
-        <button className="settings-btn" onClick={() => navigate('/settings')}>
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-            <circle cx="12" cy="12" r="3" stroke="#3A2B20" strokeWidth="2"/>
-            <path d="M12 5V3M12 21V19M19 12H21M3 12H5M17.6 17.6L19 19M5 5L6.4 6.4M6.4 17.6L5 19M19 5L17.6 6.4" stroke="#3A2B20" strokeWidth="2"/>
-          </svg>
+    <div style={screenStyles.container} onScroll={handleScroll}>
+      {/* Header */}
+      <div style={screenStyles.header}>
+        <h1 style={screenStyles.title}>Snaplet</h1>
+        <button style={screenStyles.settingsBtn} onClick={() => navigate('/settings')}>
+          ⚙️
         </button>
       </div>
 
@@ -126,7 +123,7 @@ const HomeScreen = () => {
             opacity: refreshing ? 0.6 : 1,
           }}
         >
-          {refreshing ? 'Refreshing...' : 'Refresh Feed'}
+          {refreshing ? 'Refreshing...' : '🔄 Refresh Feed'}
         </button>
       </div>
 
@@ -360,6 +357,9 @@ const HomeScreen = () => {
         +
       </div>
 
+      {/* Spacer for bottom nav */}
+      <div style={{ height: '80px' }} />
+
       <BottomNav active="home" />
 
       <style>{`
@@ -370,6 +370,39 @@ const HomeScreen = () => {
       `}</style>
     </div>
   );
+};
+
+const screenStyles = {
+  container: {
+    backgroundColor: '#F5E6D3',
+    minHeight: '100vh',
+    overflowY: 'auto',
+    paddingBottom: '20px',
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '16px 20px',
+    backgroundColor: '#F5E6D3',
+    borderBottom: '1px solid #E0D5C7',
+    position: 'sticky',
+    top: 0,
+    zIndex: 100,
+  },
+  title: {
+    fontSize: '24px',
+    fontWeight: '700',
+    margin: 0,
+    color: '#3A2B20',
+  },
+  settingsBtn: {
+    background: 'none',
+    border: 'none',
+    fontSize: '24px',
+    cursor: 'pointer',
+    padding: '4px',
+  },
 };
 
 export default HomeScreen;

--- a/src/screens/MessagesScreen.js
+++ b/src/screens/MessagesScreen.js
@@ -110,13 +110,17 @@ const MessagesScreen = () => {
   }
 
   return (
-    <div className="screen messages-screen" style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+    <div style={{ backgroundColor: '#F5E6D3', minHeight: '100vh', display: 'flex', flexDirection: 'column', paddingBottom: '70px' }}>
       {/* Header */}
       <div style={{
-        padding: '16px',
-        borderBottom: '1px solid #eee'
+        padding: '16px 20px',
+        backgroundColor: '#F5E6D3',
+        borderBottom: '1px solid #E0D5C7',
+        position: 'sticky',
+        top: 0,
+        zIndex: 100,
       }}>
-        <h1 style={{ margin: '0 0 16px', fontSize: '24px', fontWeight: '600' }}>Messages</h1>
+        <h1 style={{ margin: '0 0 16px', fontSize: '24px', fontWeight: '700', color: '#3A2B20' }}>💬 Messages</h1>
 
         {/* Search bar */}
         <div style={{

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -178,16 +178,20 @@ const ProfileScreen = () => {
   const groupedPosts = groupPostsByMonth(userPosts);
 
   return (
-    <div className="screen profile-screen" style={{ overflowY: 'auto', height: '100vh', paddingBottom: '80px' }}>
+    <div style={{ backgroundColor: '#F5E6D3', minHeight: '100vh', overflowY: 'auto', paddingBottom: '80px' }}>
       {/* Header */}
-      <div className="profile-header" style={{
+      <div style={{
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
-        padding: '16px',
-        borderBottom: '1px solid #eee'
+        padding: '16px 20px',
+        backgroundColor: '#F5E6D3',
+        borderBottom: '1px solid #E0D5C7',
+        position: 'sticky',
+        top: 0,
+        zIndex: 100,
       }}>
-        <h1 className="profile-title" style={{ margin: 0, fontSize: '20px' }}>Profile</h1>
+        <h1 style={{ margin: 0, fontSize: '24px', fontWeight: '700', color: '#3A2B20' }}>👤 Profile</h1>
         <button
           onClick={handleLogout}
           style={{

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -1,50 +1,163 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import BottomNav from '../components/BottomNav';
+import { useUserStore } from '../store/userStore';
 
 const SettingsScreen = () => {
   const navigate = useNavigate();
+  const { logout } = useUserStore();
 
   const settingsItems = [
-    { icon: '👤', label: 'Account', path: '/settings/account' },
-    { icon: '🔔', label: 'Notifications', path: '/settings/notifications' },
-    { icon: '👁️', label: 'Appearance', path: '/settings/appearance' },
-    { icon: '🔒', label: 'Privacy & Security', path: '/settings/privacy' },
-    { icon: '🎧', label: 'Help and Support', path: '/settings/help' },
-    { icon: '💡', label: 'About', path: '/settings/about' },
+    { icon: '👤', label: 'Account', path: '/profile' },
+    { icon: '🔔', label: 'Notifications', path: null },
+    { icon: '🎨', label: 'Appearance', path: null },
+    { icon: '🔒', label: 'Privacy & Security', path: null },
+    { icon: '❓', label: 'Help and Support', path: null },
+    { icon: '📱', label: 'About', path: null },
   ];
 
+  const handleLogout = async () => {
+    try {
+      await logout();
+      navigate('/login');
+    } catch (err) {
+      console.error('Logout error:', err);
+    }
+  };
+
   return (
-    <div className="screen settings-screen">
+    <div style={styles.container}>
       {/* Header */}
-      <div className="settings-header">
-        <button className="back-btn" onClick={() => navigate(-1)}>&larr;</button>
-        <h1 className="settings-title">Settings</h1>
+      <div style={styles.header}>
+        <button style={styles.backBtn} onClick={() => navigate(-1)}>←</button>
+        <h1 style={styles.title}>⚙️ Settings</h1>
+        <div style={{ width: '40px' }} />
       </div>
 
       {/* Search */}
-      <div className="search-container">
+      <div style={styles.searchContainer}>
         <input
           type="text"
-          className="search-input"
-          placeholder="search for settings"
+          style={styles.searchInput}
+          placeholder="🔍 Search settings..."
         />
       </div>
 
       {/* Settings List */}
-      <div className="settings-list">
+      <div style={styles.list}>
         {settingsItems.map((item, index) => (
-          <div key={index} className="settings-item" onClick={() => navigate(item.path)}>
-            <span className="settings-icon">{item.icon}</span>
-            <span className="settings-label">{item.label}</span>
-            <span className="settings-arrow">›</span>
+          <div
+            key={index}
+            style={styles.item}
+            onClick={() => item.path && navigate(item.path)}
+          >
+            <span style={styles.icon}>{item.icon}</span>
+            <span style={styles.label}>{item.label}</span>
+            <span style={styles.arrow}>›</span>
           </div>
         ))}
       </div>
 
+      {/* Logout Button */}
+      <div style={styles.logoutSection}>
+        <button style={styles.logoutBtn} onClick={handleLogout}>
+          🚪 Log Out
+        </button>
+      </div>
+
+      {/* Spacer for bottom nav */}
+      <div style={{ height: '80px' }} />
+
       <BottomNav active="settings" />
     </div>
   );
+};
+
+const styles = {
+  container: {
+    backgroundColor: '#F5E6D3',
+    minHeight: '100vh',
+    paddingBottom: '20px',
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '16px 20px',
+    backgroundColor: '#F5E6D3',
+    borderBottom: '1px solid #E0D5C7',
+    position: 'sticky',
+    top: 0,
+    zIndex: 100,
+  },
+  backBtn: {
+    background: 'none',
+    border: 'none',
+    fontSize: '24px',
+    cursor: 'pointer',
+    padding: '4px 8px',
+    color: '#3A2B20',
+  },
+  title: {
+    margin: 0,
+    fontSize: '24px',
+    fontWeight: '700',
+    color: '#3A2B20',
+  },
+  searchContainer: {
+    padding: '16px 20px',
+  },
+  searchInput: {
+    width: '100%',
+    padding: '12px 16px',
+    borderRadius: '12px',
+    border: '1px solid #E0D5C7',
+    backgroundColor: '#FFFFFF',
+    fontSize: '16px',
+    outline: 'none',
+    boxSizing: 'border-box',
+  },
+  list: {
+    padding: '0 20px',
+  },
+  item: {
+    display: 'flex',
+    alignItems: 'center',
+    padding: '16px',
+    backgroundColor: '#FFFFFF',
+    borderRadius: '12px',
+    marginBottom: '8px',
+    cursor: 'pointer',
+    transition: 'background-color 0.2s',
+  },
+  icon: {
+    fontSize: '24px',
+    marginRight: '16px',
+  },
+  label: {
+    flex: 1,
+    fontSize: '16px',
+    color: '#3A2B20',
+    fontWeight: '500',
+  },
+  arrow: {
+    fontSize: '20px',
+    color: '#999',
+  },
+  logoutSection: {
+    padding: '24px 20px',
+  },
+  logoutBtn: {
+    width: '100%',
+    padding: '14px',
+    backgroundColor: '#FFFFFF',
+    color: '#cc0000',
+    border: '1px solid #cc0000',
+    borderRadius: '12px',
+    fontSize: '16px',
+    fontWeight: '600',
+    cursor: 'pointer',
+  },
 };
 
 export default SettingsScreen;


### PR DESCRIPTION
- BottomNav: Replace broken image icons with emojis, add active state highlighting
- HomeScreen: Add sticky header, proper container styling, bottom nav spacing
- ProfileScreen: Consistent header styling with emoji
- SettingsScreen: Complete rewrite with emoji icons, styled settings list, logout button
- MessagesScreen: Consistent header and container styling

All screens now have:
- Beige (#F5E6D3) background
- Sticky headers
- Proper bottom nav spacing (80px)
- Emoji icons instead of broken image files